### PR TITLE
Fixed dualQuaternionToMatrix, init M to identity matrix

### DIFF
--- a/src/dlb_skinning_150.glslv
+++ b/src/dlb_skinning_150.glslv
@@ -23,7 +23,7 @@ out vec2 v_TexCoord;
 
 mat4 dualQuaternionToMatrix(vec4 qReal, vec4 qDual) {
 
-	mat4 M;
+	mat4 M = mat4(1.0);
 
 	float len2 = dot(qReal, qReal);
 	float w = qReal.x, x = qReal.y, y = qReal.z, z = qReal.w;


### PR DESCRIPTION
Apparently the older version of OpenGL on my mac automagically inits mat4's to identity matrices, but not the newer version on my linux machine ...
