### PR TITLE
Search for files referenced in assets files in their parent folders

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use collada::document::ColladaDocument;
@@ -50,7 +50,8 @@ pub struct DifferenceClipDef {
 
 impl<T: Transform> AnimationClip<T> {
 
-    pub fn from_def(clip_def: &AnimationClipDef) -> AnimationClip<T> {
+    /// `parent_folder` is the folder to search for the `AnimationClip`'s source file
+    pub fn from_def(clip_def: &AnimationClipDef, parent_folder: PathBuf) -> AnimationClip<T> {
 
         // Wacky. Shouldn't it be an error if the struct field isn't present?
         // FIXME - use an Option
@@ -61,7 +62,9 @@ impl<T: Transform> AnimationClip<T> {
         };
 
         // FIXME - load skeleton separately?
-        let collada_document = ColladaDocument::from_path(&Path::new(&clip_def.source[..])).unwrap();
+        let mut source_path = parent_folder;
+        source_path.push(&clip_def.source);
+        let collada_document = ColladaDocument::from_path(&source_path).unwrap();
         let animations = collada_document.get_animations().unwrap();
         let skeleton_set = collada_document.get_skeletons().unwrap();
         let skeleton = Skeleton::from_collada(&skeleton_set[0]);


### PR DESCRIPTION
Currently, paths in files loaded by `AssetManager::load_assets` must be either absolute paths or relative to the CWD. However, I think it is more useful to search in the folder containing the assets file so that paths in it don't have to care about where it is located.